### PR TITLE
Integrate with installer

### DIFF
--- a/playbooks/openshift-monitoring/README.md
+++ b/playbooks/openshift-monitoring/README.md
@@ -1,0 +1,26 @@
+# OpenShift Monitoring
+
+This playbook installs the OpenShift Monitoring stack.
+
+## GCP Development
+
+1. [Launch a GCP cluster](https://github.com/openshift/release/tree/master/cluster/test-deploy).
+
+2. Hack on the installer locally.
+
+3. Make changes, and then build a new openshift-ansible image.
+
+```shell
+# in openshift-ansible
+docker build -f images/installer/Dockerfile -t openshift-ansible .
+```
+
+4. Run the openshift-monitoring GCP installer against the cluster.
+
+```shell
+# in test-deploy
+make WHAT=dmacedev OPENSHIFT_ANSIBLE_IMAGE=openshift-ansible sh
+
+# in the resulting container shell
+ansible-playbook playbooks/openshift-monitoring/install-gcp.yml
+```

--- a/playbooks/openshift-monitoring/install-gcp.yml
+++ b/playbooks/openshift-monitoring/install-gcp.yml
@@ -1,0 +1,10 @@
+---
+- hosts: localhost
+  connection: local
+  tasks:
+  - name: place all scale groups into Ansible groups
+    include_role:
+      name: openshift_gcp
+      tasks_from: setup_scale_group_facts.yml
+
+- import_playbook: ./config.yml


### PR DESCRIPTION
Integrate with the component installer, and add a GCP installer shim to
facilitate local development. Add some docs.